### PR TITLE
Add the integ test to the pipeline

### DIFF
--- a/lib/agigw-stack.ts
+++ b/lib/agigw-stack.ts
@@ -5,6 +5,8 @@ import * as fs from 'fs';
 import * as path from 'path'
 
 export class APIGWStack extends cdk.Stack {
+  public static readonly URL_OUTPUT = 'MeerkatApiGwUrlOutput';
+
   public readonly handler: lambda.Function;
 
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
@@ -17,10 +19,15 @@ export class APIGWStack extends cdk.Stack {
       environment: {
         TABLE_NAME: 'MeerkatTable'
       },
+      description: 'Fake description to force a redeploy of the stack.',
     });
 
-    new apigw.LambdaRestApi(this, 'APIGW', {
+    const lambdaRestApi = new apigw.LambdaRestApi(this, 'APIGW', {
       handler: this.handler
-    })
+    });
+    // add an output with a well-known name to read it from the integ tests
+    new cdk.CfnOutput(this, APIGWStack.URL_OUTPUT, {
+      value: lambdaRestApi.url,
+    });
   }
 }

--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -4,6 +4,7 @@ import codepipeline_actions = require('@aws-cdk/aws-codepipeline-actions');
 import *  as cdk from '@aws-cdk/core';
 import *  as kms from '@aws-cdk/aws-kms';
 import *  as s3 from '@aws-cdk/aws-s3';
+import { APIGWStack } from './agigw-stack';
 
 export class PipelineStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
@@ -24,6 +25,9 @@ export class PipelineStack extends cdk.Stack {
 
     const sourceOutput = new codepipeline.Artifact();
     const cdkBuildOutput = new codepipeline.Artifact();
+    // this is the artifact that will record the output containing the generated URL of the API Gateway
+    const apiGwStackOutputs = new codepipeline.Artifact();
+
     new codepipeline.Pipeline(this, 'Pipeline', {
       artifactBucket: pipelineBucket,
       pipelineName: 'MeerkatsPipeline',
@@ -86,6 +90,30 @@ export class PipelineStack extends cdk.Stack {
               stackName: 'Meerkats-APIGWStack',
               adminPermissions: true,
               runOrder: 2,
+              // generate a file with the outputs
+              // (in this case, just the generated URL of the API Gateway endpoint)
+              output: apiGwStackOutputs,
+              outputFileName: 'outputs.json',
+            }),
+            new codepipeline_actions.CodeBuildAction({
+              actionName: 'Integ_Test',
+              input: apiGwStackOutputs,
+              runOrder: 3,
+              project: new codebuild.PipelineProject(this, 'IntegTestProject', {
+                buildSpec: codebuild.BuildSpec.fromObject({
+                  version: '0.2',
+                  phases: {
+                    build: {
+                      commands: [
+                        'set -e',
+                        // take out the URL of the API Gateway from the outputs.json file produced by the previous CFN deploy Action
+                        `api_gw_url=$(node -e 'console.log(require("./outputs.json")["${APIGWStack.URL_OUTPUT}"]);')`,
+                        'curl $api_gw_url',
+                      ],
+                    },
+                  },
+                }),
+              }),
             }),
           ],
         },


### PR DESCRIPTION
This is based on #2 , and adds an integ test that `curl`s the API Gateway endpoint.