### PR TITLE
Add validation to the CdkPipeline L3 that the deployment order does not violate the stack dependency order

### DIFF
--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -67,6 +67,9 @@ export class PipelineStack extends cdk.Stack {
           baseActionName: 'Deploy_DynamoDB_Stack',
           input: cdkBuildOutput,
           stack: props.ddbStack,
+          // either uncomment this line, or comment out the entire action addition to the `actions` array,
+          // to see synthesis fail with a validation error
+          // baseRunOrder: 7,
         }),
         // then, deploy the API Gateway Stack
         new DeployCdkStackAction({

--- a/lib/proposed_api/cdk-pipeline.ts
+++ b/lib/proposed_api/cdk-pipeline.ts
@@ -52,4 +52,57 @@ export class CdkPipeline extends cdk.Construct {
   public addStage(stageOptions: codepipeline.StageOptions): codepipeline.IStage {
     return this.pipeline.addStage(stageOptions);
   }
+
+  protected validate(): string[] {
+    const ret = new Array<string>();
+
+    const stages = this.pipeline.stages;
+
+    // validate that the order in the pipeline does not violate the stack dependency order
+    for (let baseStageNr = 0; baseStageNr < stages.length; baseStageNr++) {
+      const baseStage = stages[baseStageNr];
+      for (const baseAction of baseStage.actions) {
+        if (!(baseAction instanceof DeployCdkStackAction)) {
+          continue;
+        }
+        // temporary workaround for the stack dependency problem fixed in https://github.com/aws/aws-cdk/pull/6458
+        // just skip the validation for the CodePipeline stack
+        if (baseAction._stack === cdk.Stack.of(this)) {
+          continue;
+        }
+        for (const dep of baseAction._stack.dependencies) {
+          // search for the dependency among all stacks deployed by this pipeline
+          let found = false;
+          for (let depStageNr = 0; depStageNr < stages.length; depStageNr++) {
+            for (const depAction of stages[depStageNr].actions) {
+              if (!(depAction instanceof DeployCdkStackAction)) {
+                continue;
+              }
+              if (dep === depAction._stack) {
+                found = true;
+
+                // it's an error if the dependency is either in a later stage,
+                // or in the same stage, but not with a lower runOrder
+                if (baseStageNr < depStageNr || (baseStageNr === depStageNr &&
+                    baseAction._createChangeSetRunOrder <= depAction._createChangeSetRunOrder)) {
+                  ret.push(`Stack '${baseAction._stack.stackName}' depends on stack ` +
+                      `'${dep.stackName}', but is deployed before it in the pipeline!`);
+                }
+
+                // no point iterating anymore, break
+                break;
+              }
+            }
+          }
+
+          if (!found) {
+            ret.push(`Stack '${baseAction._stack.stackName}' depends on stack ` +
+                `'${dep.stackName}', but that dependency is not deployed through the pipeline!`);
+          }
+        }
+      }
+    }
+
+    return ret;
+  }
 }


### PR DESCRIPTION
Do it in the `validate` method, as we're guaranteed at that point that the dependencies between the stacks are populated (the 'validate' phase runs after the 'prepare' phase).