### PR TITLE
chore: add automerge workflows to repository

### DIFF
--- a/.github/workflows/auto-approve-dependabot.yml
+++ b/.github/workflows/auto-approve-dependabot.yml
@@ -1,0 +1,27 @@
+# Automatically approve PRs made by Dependabot
+#
+# Written to look at the original author of the PR (instead of the current
+# actor) in order to be able to backresolve existing PRs using this action (by
+# mass labeling them). Leads to slightly unnecessary spammage of aprovals in a
+# PR...
+#
+# Only does approvals! A different GitHub Action takes care of merging.
+name: Auto-approve Dependabot
+on:
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+      - unlabeled
+      - unlocked
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hmarr/auto-approve-action@7782c7e2bdf62b4d79bdcded8332808fd2f179cd
+      if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'dependabot-preview[bot]'
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto-merge-prs.yml
+++ b/.github/workflows/auto-merge-prs.yml
@@ -1,0 +1,50 @@
+# Automatically Merge Pull Requests
+#
+# Is aware of Dependabot and will treat its pull requests differently.
+#
+# Uses https://github.com/marketplace/actions/merge-pull-requests
+name: Automerge Completed PRs
+on:
+  pull_request:
+    types:
+      - reopened
+      - unlocked
+      - unlabeled
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+env:
+  # Settings which are the same between the 2 jobs
+  MERGE_LABELS: "!do-not-merge"
+  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  MERGE_METHOD: "squash"
+  MERGE_DELETE_BRANCH: "true"
+  MERGE_RETRIES: "3"
+  MERGE_RETRY_SLEEP: "60000"
+jobs:
+  automerge_regular:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot-preview[bot]'
+        uses: "pascalgn/automerge-action@a4b03eff945989d41c623c2784d6602560b91e5b"
+        env:
+          MERGE_COMMIT_MESSAGE: "pull-request-title-and-description"
+          UPDATE_LABELS: "!do-not-merge"
+  automerge_dependabot:
+    # Different behavior for dependabot PRs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'dependabot-preview[bot]'
+        uses: "pascalgn/automerge-action@a4b03eff945989d41c623c2784d6602560b91e5b"
+        env:
+          # Don't merge from master (Dependabot will do that itself)
+          UPDATE_LABELS: "NEVER_MATCHES"
+          # Don't use the PR content as the squash merge message (use the
+          # original commit message instead).
+          MERGE_COMMIT_MESSAGE: "automatic"


### PR DESCRIPTION
Includes automatic dependabot merging which is not super useful
since dependabot has not been enabled on this repo, but it
doesn't really hurt either.