### PR TITLE
Break dependency between pipeline and application stack

### DIFF
--- a/bin/cicdk.ts
+++ b/bin/cicdk.ts
@@ -7,9 +7,9 @@ import { PipelineStack } from '../lib/pipeline-stack';
 
 const app = new cdk.App();
 
-const apiGwStack = new APIGWStack(app, 'Meerkats-APIGWStack');
-const ddbStack = new DDBStack(app, 'Meerkats-DDBStack', {
-  grantRead: [apiGwStack.handler]
+const ddbStack = new DDBStack(app, 'Meerkats-DDBStack');
+const apiGwStack = new APIGWStack(app, 'Meerkats-APIGWStack', {
+  table: ddbStack.table
 });
 
 new PipelineStack(app, 'MeertkatsCodePipelineStack', {

--- a/lib/ddb-stack.ts
+++ b/lib/ddb-stack.ts
@@ -3,23 +3,20 @@ import * as ddb from '@aws-cdk/aws-dynamodb';
 import { IGrantable } from '@aws-cdk/aws-iam';
 
 export interface DDBStackProps extends cdk.StackProps {
-  readonly grantRead?: IGrantable[];
 }
 
 export class DDBStack extends cdk.Stack {
+  public readonly table: ddb.Table;
+
   constructor(scope: cdk.Construct, id: string, props: DDBStackProps = {}) {
     super(scope, id, props);
-    
-    const table = new ddb.Table(this, 'MeerkatTable', {  
+
+    this.table = new ddb.Table(this, 'MeerkatTable', {
       partitionKey: {
         name: 'name',
-        type: ddb.AttributeType.STRING 
-      }, 
-      tableName: 'MeerkatTable',
+        type: ddb.AttributeType.STRING
+      },
       removalPolicy: cdk.RemovalPolicy.DESTROY,
-    });
-    props.grantRead?.forEach(grantable => {
-      table.grantFullAccess(grantable);
     });
   }
 }

--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -63,13 +63,13 @@ export class PipelineStack extends cdk.Stack {
       stageName: 'Deploy',
       actions: [
         // first, deploy the DynamoDB Stack
-        new DeployCdkStackAction({
+        new DeployCdkStackAction(this, {
           baseActionName: 'Deploy_DynamoDB_Stack',
           input: cdkBuildOutput,
           stack: props.ddbStack,
         }),
         // then, deploy the API Gateway Stack
-        new DeployCdkStackAction({
+        new DeployCdkStackAction(this, {
           baseActionName: 'Deploy_API_GW_Stack',
           input: cdkBuildOutput,
           stack: props.apiGwStack,

--- a/lib/proposed_api/cdk-pipeline.ts
+++ b/lib/proposed_api/cdk-pipeline.ts
@@ -38,7 +38,7 @@ export class CdkPipeline extends cdk.Construct {
         {
           stageName: 'Self_Mutation',
           actions: [
-            new DeployCdkStackAction({
+            new DeployCdkStackAction(this, {
               baseActionName: 'Self_Mutate',
               input: buildConfig.cdkBuildOutput,
               stack: cdk.Stack.of(this),


### PR DESCRIPTION
Break accidental dependency between Pipeline and App stacks

The current behavior of creating an imported Role in the application
stack leads to creating a dependency between the Pipeline stack and the
application stack that the Pipeline deploys.

That is incorrect behavior, since the dependency implies:

> The application stack needs to be deployed before the pipeline stack
> can be deployed.

But in actuality, the pipeline stack will create the application stack,
so there is no such ordering dependency.

1. I think the behavior that is causing the stack dependency caused by
using an imported role from another stack to appear is a bug, and should
be fixed.
2. For now, I've worked around it by creating the imported Role not in
the scope of the application stack, but in the scope of the pipeline
stack.

See motivation here:

https://github.com/NetaNir/meerkats/pull/10/files#diff-efc69af2b71d5cced17ba37e959fb3abR39