### PR TITLE
Make the assets publishing run in a privileged CodeBuild project

### DIFF
--- a/lib/proposed_api/publish-assets-action.ts
+++ b/lib/proposed_api/publish-assets-action.ts
@@ -43,6 +43,9 @@ export class PublishAssetsAction extends Construct implements codepipeline.IActi
           },
         },
       }),
+      environment: {
+        privileged: true, // needed to perform Docker builds
+      },
     });
 
     project.addToRolePolicy(new iam.PolicyStatement({


### PR DESCRIPTION
Necessary for building Docker image assets.