### PR TITLE
WIP - Add an aspect which adds a Canaries stacks to each stage

### DIFF
--- a/bin/cicdk.ts
+++ b/bin/cicdk.ts
@@ -16,6 +16,7 @@ new APIGWStack(app, `Dev-Meerkats-APIGWStack`, {
   cluster: ddbStack.cluster,
 });
 
+
 new PipelineStack(app, 'MeertkatsCodePipelineStack', {
   env: {
     region: 'us-west-2',

--- a/lib/aspects/canary-aspect.ts
+++ b/lib/aspects/canary-aspect.ts
@@ -1,0 +1,41 @@
+import { IAspect, IConstruct, Stack, CfnResource, CfnOutput, Construct } from "@aws-cdk/core";
+import { BaseLoadBalancer } from "@aws-cdk/aws-elasticloadbalancingv2";
+import { Integration } from '@aws-cdk/aws-apigateway';
+import { Canary } from "../canaries/canary";
+import { CdkStage } from "../proposed_api/cdk-pipeline";
+
+export class CanaryAspect implements IAspect {
+  _canaryStack: Stack;
+
+  constructor(private readonly scope: Construct, private readonly stage: CdkStage) {}
+
+  public visit(node: IConstruct): void {
+    if (Stack.isStack(node)) {
+      const children = node.node.children;
+      children.forEach( ch => {
+        // we can add more types here, APIGateway etc.
+        if (ch instanceof BaseLoadBalancer) { 
+          new Canary(this.canaryStack, `Canary-${ch.node.uniqueId}`, {
+            url: ch.loadBalancerDnsName
+          });
+          (node as Stack).addDependency(this.canaryStack);
+        }
+      })
+    }
+  }
+
+  get canaryStack(): Stack {
+    if (this._canaryStack === undefined) {
+      // TODO sanitize stage name
+      let stackname = this.stage.stageName.replace(/_/g, '-');
+      // Where will we create the canary stack? temporaraly creating it in the pipeline account 
+      this._canaryStack = new Stack(this.scope, `CanaryStack-${stackname}`, {
+        env: {
+          account: '355421412380',
+          region: 'us-east-1'
+        }
+      });
+    }
+    return this._canaryStack; 
+  }
+}

--- a/lib/canaries/canary.ts
+++ b/lib/canaries/canary.ts
@@ -1,0 +1,42 @@
+import * as events from '@aws-cdk/aws-events';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as targets from '@aws-cdk/aws-events-targets';
+import * as cloudwatch from '@aws-cdk/aws-cloudwatch';
+import { Construct, Duration } from '@aws-cdk/core';
+import * as path from 'path';
+
+export interface CanaryProps {
+  readonly url: string;
+}
+
+export class Canary extends Construct {
+  constructor(scope: Construct, id: string, props: CanaryProps)  {
+    super(scope, id);
+    
+    const canaryLambda = new lambda.Function(this, 'CanaryLambda', {
+      handler: 'apiCanaryBlueprint.handler',
+      runtime: lambda.Runtime.NODEJS_10_X,
+      code: lambda.Code.fromAsset(path.resolve(__dirname, "./canary-lambda")),
+      environment: {
+        API_URL: props.url
+      },
+    });
+    
+    // create a cloudwatch event rule 
+    const rule = new events.Rule(this, 'CanaryRule', {
+      schedule: events.Schedule.expression('rate(5 minutes)'),
+      targets: [ new targets.LambdaFunction(canaryLambda) ] 
+    });
+    
+    // create a cloudwatch alarm based on the lambda erros metrics
+    new cloudwatch.Alarm(this, 'CanaryAlarm', {
+      metric: canaryLambda.metricErrors(),
+      threshold: 0,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+      treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+      period: Duration.minutes(5),
+      alarmName: 'CanaryAlarm',
+    });
+  }
+}

--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -10,6 +10,7 @@ import { CdkPipeline, CdkStack, CdkStage } from "./proposed_api/cdk-pipeline";
 import { DeployCdkStackAction } from "./proposed_api/deploy-cdk-stack-action";
 import { ShellCommandsValidation, IValidation } from './proposed_api/validation';
 import { Environment, Stack, Construct, StackProps } from '@aws-cdk/core';
+import { CanaryAspect } from './aspects/canary-aspect';
 
 
 export class PipelineStack extends cdk.Stack {
@@ -53,6 +54,9 @@ export class PipelineStack extends cdk.Stack {
     };
 
     const beta = createStage(scope, betaEnv, 'beta_a1_UsWest2', true);
+    // Creating the aspect here gives us the ability to add an adpect per application stage
+    scope.node.applyAspect(new CanaryAspect(scope, beta));
+
     pipeline.addCdkStage(beta);
 
     const gamma = createStage(scope, gammaEnv, 'gamma_a1_EuWest1', true);


### PR DESCRIPTION
This is a second/parallel branch intended to add an aspect which creates a stack during `visit`.  The stack created adds a dependency between itself and all other stacks that are "canaryable" which means, they include a construct that creates an AWS service that has a reachable API such as LoadBalancer/APIGateWay etc.. 

Currently the aspect is created in the `pipeline-stack` on the stage level: 

```javascript
const beta = createStage(scope, betaEnv, 'beta_a1_UsWest2', true);
// Creating the aspect here gives us the ability to add an aspect per application stage
scope.node.applyAspect(new CanaryAspect(scope, beta));
pipeline.addCdkStage(beta);
``` 
Which means a canary stack is created per application stage.
The problem, as we expected, is that the CanaryStack is not added to the pipeline, and that's the interesting part! I'll add my less raw thoughts on this once I'll have another pass on it tomorrow.

The way the aspect created stack will be added to the pipeline will  be influenced greatly (I believe)  by the way we model what we new refer to as a stage but more generally, an instance of the application (service instance?).

### Notes 
* I intentionally didn't use the `outputArtifacts` as it's coupled to code pipeline and I don't see any missed value in not using it. I might be wrong...
* The canary construct works with the released version of the CDK but the lambda code isn't uploaded with the new fancy assets tools. @rix0rrr, help :)
* Currently I only created the aspect in beta but the goal is to add it to all stages

 

 

