### PR TITLE
Remove the trailing slash from the LoadBalancer URL CFN output

### DIFF
--- a/lib/agigw-stack.ts
+++ b/lib/agigw-stack.ts
@@ -70,7 +70,7 @@ export class APIGWStack extends cdk.Stack {
 
     // add an output with a well-known name to read it from the integ tests
     new cdk.CfnOutput(this, APIGWStack.URL_OUTPUT, {
-      value: `http://${lb.loadBalancerDnsName}/`,
+      value: `http://${lb.loadBalancerDnsName}`,
     });
   }
 }


### PR DESCRIPTION
Otherwise the container test hits <url>//container instead of <url>/container.